### PR TITLE
Correctly calculate the LMOTS public key buffer length during deserialization

### DIFF
--- a/pyhsslms/pyhsslms.py
+++ b/pyhsslms/pyhsslms.py
@@ -461,8 +461,8 @@ class LmotsPublicKey:
         if lmots_type not in lmots_params():
            raise ValueError(err_unknown_typecode, toHex(lmots_type))
         alg, n, p, w, ls = lmots_params[lmots_type]
-        rv = 4+(2*n)
-        if len(buffer) < rv:
+        rv = 4 + LenS + n
+        if len(buffer) != rv:
             raise ValueError(err_bad_length, str(len(buffer)))
         return rv
 

--- a/pyhsslms/pyhsslms.py
+++ b/pyhsslms/pyhsslms.py
@@ -443,13 +443,14 @@ class LmotsPublicKey:
         if len(buffer) < 4:
             raise ValueError(err_bad_length, str(len(buffer)))
         lmots_type = buffer[0:4]
-        if lmots_type not in lmots_params():
+        if lmots_type not in lmots_params:
            raise ValueError(err_unknown_typecode, toHex(lmots_type))
         alg, n, p, w, ls = lmots_params[lmots_type]
-        if len(buffer) != 4+(2*n):
-            raise ValueError(err_bad_length)
-        S = buffer[4:4+n]
-        K = buffer[4+n:4+2*n]
+        buf_size = 4 + LenS + n
+        if len(buffer) != buf_size:
+            raise ValueError(err_bad_length, f"{str(len(buffer))} != {buf_size}")
+        S = buffer[4:4+LenS]
+        K = buffer[4+LenS:(4+LenS)+n]
         return cls(S, K, lmots_type)
 
     @classmethod

--- a/tests/test_hsslms.py
+++ b/tests/test_hsslms.py
@@ -218,6 +218,18 @@ class TestLMS(unittest.TestCase):
         self.assertTrue(prv.prettyPrint())
         self.assertTrue(pub.prettyPrint())
 
+    def testRandomPublicKeySerializeDeserialize(self):
+        msg = toBytes('The way to get started is to quit talking and ' + \
+                      'begin doing.')
+        prv = pyhsslms.LmotsPrivateKey()
+        pub = prv.publicKey()
+        pubserial = pub.serialize()
+        pub2 = pyhsslms.LmotsPublicKey.deserialize(pubserial)
+        self.assertTrue(pub.S == pub2.S)
+        self.assertTrue(pub.K == pub2.K)
+        self.assertTrue(pub.type == pub2.type)
+        self.assertTrue(pub.prettyPrint() == pub2.prettyPrint())
+
 
 class TestHSS(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #8.