### PR TITLE
Continue support python2.7 and add support for new python3 releases

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,4 @@
 
-
 Revision 1.0.0, released 4-May-2020
 -----------------------------------
 
@@ -50,26 +49,31 @@ Revision 1.1.1, released 9-Jan-2023
 - Make it easier to run test from the command line (Contribution by
   sebastien-riou).
 
-Revision 2.0.0, released ???-Oct-2023
+
+Revision 2.0.0, released 26-Oct-2023
 ------------------------------------
 
-- Introduced new HssPrivateKey serialization scheme that allows significantly
-  larger keys to be generated. Previously, only keys that allowed for a total of
-  32-bit length signature uses were possible. This change does not break
-  reverse-compatibility for keys generated using the old serialization scheme.
-  (Contribution by joshuayuen99).
+- HssPrivateKey serialization supports significantly larger tree sizes.
+  Previous approach allowed for a total of (2**32)-1 signature.  This
+  change does not break compatibility for private keys generated using
+  the old serialization scheme (Contribution by joshuayuen99).
 
-- Correctly generate the LMOTS public key from a given LMOTS private
-  key (Contribution by joshuayuen99).
+- Generate the LMOTS public key from a given LMOTS private key using
+  the approach documented in RFC 8554 (Contribution by joshuayuen99).
 
-- Correctly sign messages with LMOTS private keys
-  (Contribution by joshuayuen99).
+- Correctly sign messages with LMOTS private keys (Contribution by
+  joshuayuen99).
 
 - Correctly calculate the the size of the LMOTS public key during
   deserialization (Contribution by joshuayuen99).
 
-- Refactor "S" field within LmotsSignature, LmotsPrivateKey, and
-  LmotsPublicKey to "I" and "q" components as per the final RFC
+- Refactor "S" argument within LmotsSignature, LmotsPrivateKey, and
+  LmotsPublicKey to "I" and "q" arguments to align with RFC 8554
   (Contribution by joshuayuen99).
 
 - Add tests for the coef function.
+
+- Include support for Classifier: Python 3.9, Python 3.10, Python 3.11,
+  and Python 3.12.
+
+- Update copyright.

--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ Source code is freely available as a GitHub [repo](https://github.com/russhousle
 
 You could `pip install pyhsslms` or download it from [PyPI](https://pypi.org/project/pyhsslms).
 
-Copyright (c) 2020, Vigil Security, LLC
+Copyright (c) 2020-2023, Vigil Security, LLC
 All rights reserved.

--- a/pyhsslms/__init__.py
+++ b/pyhsslms/__init__.py
@@ -1,5 +1,5 @@
 # https://www.python.org/dev/peps/pep-0396/
-__version__ = '1.1.1'
+__version__ = '2.0.0'
 
 from .pyhsslms import lmots_sha256_n32_w1
 from .pyhsslms import lmots_sha256_n32_w2

--- a/pyhsslms/compat.py
+++ b/pyhsslms/compat.py
@@ -4,7 +4,7 @@
 # for HSS/LMS Hash-based Signatures as defined in RFC 8554.
 #
 #
-# Copyright (c) 2020-2021, Vigil Security, LLC
+# Copyright (c) 2020-2023, Vigil Security, LLC
 # All rights reserved.
 #
 # Redistribution and use, with or without modification, are permitted

--- a/pyhsslms/hsslms.py
+++ b/pyhsslms/hsslms.py
@@ -7,7 +7,7 @@
 # in RFC 8554.
 #
 #
-# Copyright (c) 2020-2021, Vigil Security, LLC
+# Copyright (c) 2020-2023, Vigil Security, LLC
 # All rights reserved.
 #
 # Redistribution and use, with or without modification, are permitted
@@ -225,7 +225,6 @@ def main():
             print("Signature in " + filename + ".sig is valid.")
         else:
             print("Signature verification failed!")
-        
 
     if sys.argv[1] == 'showprv':
         if len(sys.argv) < 3:

--- a/pyhsslms/pyhsslms.py
+++ b/pyhsslms/pyhsslms.py
@@ -11,7 +11,7 @@
 # by another program that allows different tree sizes in the hierarchy.
 #
 #
-# Copyright (c) 2020-2021, Vigil Security, LLC
+# Copyright (c) 2020-2023, Vigil Security, LLC
 # All rights reserved.
 #
 # Redistribution and use, with or without modification, are permitted
@@ -457,7 +457,7 @@ class LmotsPublicKey:
         alg, n, p, w, ls = lmots_params[lmots_type]
         buf_size = 4 + LenI + LenQ + n
         if len(buffer) != buf_size:
-            raise ValueError(err_bad_length, f"{str(len(buffer))} != {buf_size}")
+            raise ValueError(err_bad_length, "buffer size is not " + str(len(buffer)))
         I = buffer[4:4+LenI]
         q = buffer[4+LenI:4+LenI+LenQ]
         K = buffer[4+LenI+LenQ:(4+LenI+LenQ)+n]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 # defined in RFC 8554.
 #
 #
-# Copyright (c) 2020, Vigil Security, LLC
+# Copyright (c) 2020-2023, Vigil Security, LLC
 # All rights reserved.
 #
 # Redistribution and use, with or without modification, are permitted
@@ -56,6 +56,10 @@ Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Topic :: Security :: Cryptography
 Topic :: Software Development :: Libraries :: Python Modules
 """

--- a/tests/test_hsslms.py
+++ b/tests/test_hsslms.py
@@ -3,7 +3,7 @@
 # Test routines for HSS/LMS Hash-based Signatures.
 #
 #
-# Copyright (c) 2020-2021, Vigil Security, LLC
+# Copyright (c) 2020-2023, Vigil Security, LLC
 # All rights reserved.
 #
 # Redistribution and use, with or without modification, are permitted


### PR DESCRIPTION
Continue support for python2.7. Add support for python3.9, python3.10, python3.11, and python3.12. Update copyright. Release 2.0.0.
